### PR TITLE
Fixes public API by exporting Extends

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export * from "./typeGuard";
 export type { UnpackPromise } from "./UnpackPromise";
 export * from "./is";
 export type { Equals } from "./Equals";
+export type { Extends } from "./Extends";
 export type { Not } from "./Not";
 export * from "./objectEntries";
 export * from "./objectFromEntries";


### PR DESCRIPTION
Hi @garronej,
I forgot to update the public API defined in index.ts.
This PR adds the missing export of the new Extends type.
Could you please release 1.1.1 containing this patch?
Many thanks!

_(Note: The Gitbook update is also on its way soon...)_