### PR TITLE
feat(assert): store original message in `AssertionError`

### DIFF
--- a/src/assert.ts
+++ b/src/assert.ts
@@ -5,8 +5,12 @@ export type { Equals } from "./Equals";
 
 /** @see <https://docs.tsafe.dev/assert#error-thrown> */
 export class AssertionError extends Error {
+    originalMessage?: string;
+
     constructor(msg: string | undefined) {
         super(`Wrong assertion encountered` + (!msg ? "" : `: "${msg}"`));
+
+        this.originalMessage = msg;
 
         Object.setPrototypeOf(this, new.target.prototype);
 

--- a/test/assertIs.ts
+++ b/test/assertIs.ts
@@ -122,3 +122,12 @@ scope: {
         console.log("PASS");
     }
 }
+
+/**
+ * `AssertionError` should store the original message in the `originalMessage` property.
+ */
+{
+    const error = new AssertionError("message");
+    assert(error.originalMessage === "message");
+    console.log("PASS");
+}


### PR DESCRIPTION
`AssertionError` wraps the message provided during instantiation with some additional text:

```ts
const error = new AssertionError("message");
console.log(error.message); // 'Wrong assertion encountered: "message"'
```

This helpfully communicates that the error resulted from a failed assertion.

Sometimes we want to access the original message without the wrapper text. For example, we may wish to surface the error directly to a user.

This change adds an `originalMessage` property to `AssertionError` to store the original message without any wrapper text.

The existing behaviour is unchanged, but library consumers now have access to the original message.

Closes #35